### PR TITLE
Removing extra closing parenthesis

### DIFF
--- a/index.md
+++ b/index.md
@@ -40,7 +40,7 @@ subscript longer_of(_ a: inout String, _ b: inout String): String {
 }
 
 fun emphasize(_ z: inout String, strength: Int = 1) {
-  z.append(repeat_element("!", count: strength)))
+  z.append(repeat_element("!", count: strength))
 }
 
 public fun main() {


### PR DESCRIPTION
The simple program example includes an extra closing parenthesis. This results in a syntax error.